### PR TITLE
Fix for select error state

### DIFF
--- a/src/forms/select/_select.scss
+++ b/src/forms/select/_select.scss
@@ -72,5 +72,6 @@
     &.ds_input--error, /// [1]
     &.ds_select--error {
         @include ds_field-error;
+        min-height: 52px;
     }
 }


### PR DESCRIPTION
Select error state causes the border to be cut off.
It happens because the border changes from `2px` to `4px` which leaves 4px gap.
<img width="326" alt="select-error-state" src="https://user-images.githubusercontent.com/1349297/133059287-e3671add-2906-4cc4-a593-5df6862cc470.png">

The fix is to increase the min-height of the wrapper by `4px` to compensate border change.
