### PR TITLE
Issue #15: Adds `type` attribute to accordion item header button

### DIFF
--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -61,6 +61,7 @@ class Accordion {
 
         itemButton.setAttribute('aria-expanded', startsOpen);
         itemButton.setAttribute('aria-controls', itemBody.id);
+        itemButton.setAttribute('type', 'button');
 
         // events
         itemButton.addEventListener('click', event => {


### PR DESCRIPTION
Resolves issue #15 by adding the `type` attribute to the accordion item buttons.